### PR TITLE
Add support for optional collection types.

### DIFF
--- a/Ogra/Encodable.swift
+++ b/Ogra/Encodable.swift
@@ -62,6 +62,8 @@ extension Optional where T: Encodable {
 		case .Some(let v): return v.encode()
 		}
 	}
+}
+
 extension CollectionType where Self: DictionaryLiteralConvertible, Self.Key: StringLiteralConvertible, Self.Value: Encodable, Generator.Element == (Self.Key, Self.Value) {
     public func encode() -> JSON {
         var values = [String : JSON]()

--- a/Ogra/Encodable.swift
+++ b/Ogra/Encodable.swift
@@ -62,7 +62,7 @@ extension Optional where T: Encodable {
 		case .Some(let v): return v.encode()
 		}
 	}
-extension CollectionType where Generator.Element == (Key: StringLiteralConvertible, Value: Encodable) {
+extension CollectionType where Self: protocol<DictionaryLiteralConvertible>, Self.Key: protocol<StringLiteralConvertible>, Self.Value: Encodable, Self.Generator.Element == (Self.Key, Self.Value) {
     public func encode() -> JSON {
         var values = [String : JSON]()
         for (key, value) in self {
@@ -72,7 +72,7 @@ extension CollectionType where Generator.Element == (Key: StringLiteralConvertib
     }
 }
 
-extension Optional where T: CollectionType, T.Generator.Element == (Key: StringLiteralConvertible, Value: Encodable) {
+extension Optional where T: protocol<CollectionType, DictionaryLiteralConvertible>, T.Key: protocol<StringLiteralConvertible>, T.Value: Encodable, T.Generator.Element == (T.Key, T.Value) {
     public func encode() -> JSON {
         return self.map { $0.encode() } ?? .Null
     }

--- a/Ogra/Encodable.swift
+++ b/Ogra/Encodable.swift
@@ -62,7 +62,7 @@ extension Optional where T: Encodable {
 		case .Some(let v): return v.encode()
 		}
 	}
-extension CollectionType where Self: protocol<DictionaryLiteralConvertible>, Self.Key: protocol<StringLiteralConvertible>, Self.Value: Encodable, Generator.Element == (Self.Key, Self.Value) {
+extension CollectionType where Self: DictionaryLiteralConvertible, Self.Key: protocol<StringLiteralConvertible>, Self.Value: Encodable, Generator.Element == (Self.Key, Self.Value) {
     public func encode() -> JSON {
         var values = [String : JSON]()
         for (key, value) in self {

--- a/Ogra/Encodable.swift
+++ b/Ogra/Encodable.swift
@@ -62,19 +62,23 @@ extension Optional where T: Encodable {
 		case .Some(let v): return v.encode()
 		}
 	}
+extension CollectionType where Generator.Element == (Key: StringLiteralConvertible, Value: Encodable) {
+    public func encode() -> JSON {
+        var values = [String : JSON]()
+        for (key, value) in self {
+            values[String(key)] = value.encode()
+        }
+        return .Object(values)
+    }
 }
 
-extension Dictionary where Key: StringLiteralConvertible, Value: Encodable {
-	public func encode() -> JSON {
-		var values = [String : JSON]()
-		for (key, value) in self {
-			values[String(key)] = value.encode()
-		}
-		return .Object(values)
-	}
+extension Optional where T: CollectionType, T.Generator.Element == (Key: StringLiteralConvertible, Value: Encodable) {
+    public func encode() -> JSON {
+        return self.map { $0.encode() } ?? .Null
+    }
 }
 
-extension CollectionType where Self.Generator.Element: Encodable {
+extension CollectionType where Generator.Element: Encodable {
     public func encode() -> JSON {
         return JSON.Array(self.map { $0.encode() })
     }

--- a/Ogra/Encodable.swift
+++ b/Ogra/Encodable.swift
@@ -62,7 +62,7 @@ extension Optional where T: Encodable {
 		case .Some(let v): return v.encode()
 		}
 	}
-extension CollectionType where Self: protocol<DictionaryLiteralConvertible>, Self.Key: protocol<StringLiteralConvertible>, Self.Value: Encodable, Self.Generator.Element == (Self.Key, Self.Value) {
+extension CollectionType where Self: protocol<DictionaryLiteralConvertible>, Self.Key: protocol<StringLiteralConvertible>, Self.Value: Encodable, Generator.Element == (Self.Key, Self.Value) {
     public func encode() -> JSON {
         var values = [String : JSON]()
         for (key, value) in self {

--- a/Ogra/Encodable.swift
+++ b/Ogra/Encodable.swift
@@ -74,10 +74,16 @@ extension Dictionary where Key: StringLiteralConvertible, Value: Encodable {
 	}
 }
 
-extension Array where Element: Encodable {
-	public func encode() -> JSON {
-		return JSON.Array(self.map { $0.encode() })
-	}
+extension CollectionType where Self.Generator.Element: Encodable {
+    public func encode() -> JSON {
+        return JSON.Array(self.map { $0.encode() })
+    }
+}
+
+extension Optional where T: CollectionType, T.Generator.Element: Encodable {
+    public func encode() -> JSON {
+        return self.map { $0.encode() } ?? .Null
+    }
 }
 
 extension JSON {

--- a/Ogra/Encodable.swift
+++ b/Ogra/Encodable.swift
@@ -65,31 +65,31 @@ extension Optional where T: Encodable {
 }
 
 extension CollectionType where Self: DictionaryLiteralConvertible, Self.Key: StringLiteralConvertible, Self.Value: Encodable, Generator.Element == (Self.Key, Self.Value) {
-    public func encode() -> JSON {
-        var values = [String : JSON]()
-        for (key, value) in self {
-            values[String(key)] = value.encode()
-        }
-        return .Object(values)
-    }
+	public func encode() -> JSON {
+		var values = [String : JSON]()
+		for (key, value) in self {
+			values[String(key)] = value.encode()
+		}
+		return .Object(values)
+	}
 }
 
 extension Optional where T: protocol<CollectionType, DictionaryLiteralConvertible>, T.Key: StringLiteralConvertible, T.Value: Encodable, T.Generator.Element == (T.Key, T.Value) {
-    public func encode() -> JSON {
-        return self.map { $0.encode() } ?? .Null
-    }
+	public func encode() -> JSON {
+		return self.map { $0.encode() } ?? .Null
+	}
 }
 
 extension CollectionType where Generator.Element: Encodable {
-    public func encode() -> JSON {
-        return JSON.Array(self.map { $0.encode() })
-    }
+	public func encode() -> JSON {
+		return JSON.Array(self.map { $0.encode() })
+	}
 }
 
 extension Optional where T: CollectionType, T.Generator.Element: Encodable {
-    public func encode() -> JSON {
-        return self.map { $0.encode() } ?? .Null
-    }
+	public func encode() -> JSON {
+		return self.map { $0.encode() } ?? .Null
+	}
 }
 
 extension JSON {

--- a/Ogra/Encodable.swift
+++ b/Ogra/Encodable.swift
@@ -62,7 +62,7 @@ extension Optional where T: Encodable {
 		case .Some(let v): return v.encode()
 		}
 	}
-extension CollectionType where Self: DictionaryLiteralConvertible, Self.Key: protocol<StringLiteralConvertible>, Self.Value: Encodable, Generator.Element == (Self.Key, Self.Value) {
+extension CollectionType where Self: DictionaryLiteralConvertible, Self.Key: StringLiteralConvertible, Self.Value: Encodable, Generator.Element == (Self.Key, Self.Value) {
     public func encode() -> JSON {
         var values = [String : JSON]()
         for (key, value) in self {
@@ -72,7 +72,7 @@ extension CollectionType where Self: DictionaryLiteralConvertible, Self.Key: pro
     }
 }
 
-extension Optional where T: protocol<CollectionType, DictionaryLiteralConvertible>, T.Key: protocol<StringLiteralConvertible>, T.Value: Encodable, T.Generator.Element == (T.Key, T.Value) {
+extension Optional where T: protocol<CollectionType, DictionaryLiteralConvertible>, T.Key: StringLiteralConvertible, T.Value: Encodable, T.Generator.Element == (T.Key, T.Value) {
     public func encode() -> JSON {
         return self.map { $0.encode() } ?? .Null
     }

--- a/OgraTests/OgraModel.swift
+++ b/OgraTests/OgraModel.swift
@@ -28,7 +28,7 @@ extension User: Decodable, Encodable {
 	static func create(id: Int)(name: String)(email: String?)(pet: Pet?)(nicknames: [String]?)(accounts: [String:String]?) -> User {
 		return User(id:id, name:name, email:email, pet:pet, nicknames:nicknames, accounts:accounts)
 	}
-	
+
 	static func decode(j: JSON) -> Decoded<User> {
 		return create
 			<^> j <|   "id"

--- a/OgraTests/OgraModel.swift
+++ b/OgraTests/OgraModel.swift
@@ -16,6 +16,7 @@ struct User {
 	let name: String
 	let email: String?
 	let pet: Pet?
+    let nicknames: [String]?
 }
 struct Pet {
 	let name: String
@@ -23,26 +24,28 @@ struct Pet {
 
 // MARK: - JSON Encoding and Decoding
 extension User: Decodable, Encodable {
-	static func create(id: Int)(name: String)(email: String?)(pet: Pet?) -> User {
-		return User(id:id, name:name, email:email, pet:pet)
-	}
-
-	static func decode(j: JSON) -> Decoded<User> {
-		return create
-			<^> j <|  "id"
-			<*> j <|  "name"
-			<*> j <|? "email"
-			<*> j <|? "pet"
-	}
-	
-	func encode() -> JSON {
-		return JSON.Object([
-			"id"    : self.id.encode(),
-			"name"  : self.name.encode(),
-			"email" : self.email.encode(),
-			"pet"   : self.pet.encode()
-		])
-	}
+    static func create(id: Int)(name: String)(email: String?)(pet: Pet?)(nicknames: [String]?) -> User {
+        return User(id:id, name:name, email:email, pet:pet, nicknames:nicknames)
+    }
+    
+    static func decode(j: JSON) -> Decoded<User> {
+        return create
+            <^> j <|   "id"
+            <*> j <|   "name"
+            <*> j <|?  "email"
+            <*> j <|?  "pet"
+            <*> j <||? "nicknames"
+    }
+    
+    func encode() -> JSON {
+        return JSON.Object([
+            "id"        : self.id.encode(),
+            "name"      : self.name.encode(),
+            "email"     : self.email.encode(),
+            "pet"       : self.pet.encode(),
+            "nicknames" : self.nicknames.encode()
+        ])
+    }
 }
 
 extension Pet: Decodable, Encodable {

--- a/OgraTests/OgraModel.swift
+++ b/OgraTests/OgraModel.swift
@@ -16,8 +16,8 @@ struct User {
 	let name: String
 	let email: String?
 	let pet: Pet?
-    let nicknames: [String]?
-    let accounts: [String:String]?
+	let nicknames: [String]?
+	let accounts: [String:String]?
 }
 struct Pet {
 	let name: String
@@ -25,30 +25,30 @@ struct Pet {
 
 // MARK: - JSON Encoding and Decoding
 extension User: Decodable, Encodable {
-    static func create(id: Int)(name: String)(email: String?)(pet: Pet?)(nicknames: [String]?)(accounts: [String:String]?) -> User {
-        return User(id:id, name:name, email:email, pet:pet, nicknames:nicknames, accounts:accounts)
-    }
-    
-    static func decode(j: JSON) -> Decoded<User> {
-        return create
-            <^> j <|   "id"
-            <*> j <|   "name"
-            <*> j <|?  "email"
-            <*> j <|?  "pet"
-            <*> j <||? "nicknames"
-            <*> .optional(flatReduce(["accounts"], initial: j, combine: decodedJSON) >>- Dictionary<String, String>.decode)
-    }
-    
-    func encode() -> JSON {
-        return JSON.Object([
-            "id"        : self.id.encode(),
-            "name"      : self.name.encode(),
-            "email"     : self.email.encode(),
-            "pet"       : self.pet.encode(),
-            "nicknames" : self.nicknames.encode(),
-            "accounts"  : self.accounts.encode()
-        ])
-    }
+	static func create(id: Int)(name: String)(email: String?)(pet: Pet?)(nicknames: [String]?)(accounts: [String:String]?) -> User {
+		return User(id:id, name:name, email:email, pet:pet, nicknames:nicknames, accounts:accounts)
+	}
+	
+	static func decode(j: JSON) -> Decoded<User> {
+		return create
+			<^> j <|   "id"
+			<*> j <|   "name"
+			<*> j <|?  "email"
+			<*> j <|?  "pet"
+			<*> j <||? "nicknames"
+			<*> .optional(flatReduce(["accounts"], initial: j, combine: decodedJSON) >>- Dictionary<String, String>.decode)
+	}
+	
+	func encode() -> JSON {
+		return JSON.Object([
+			"id"        : self.id.encode(),
+			"name"      : self.name.encode(),
+			"email"     : self.email.encode(),
+			"pet"       : self.pet.encode(),
+			"nicknames" : self.nicknames.encode(),
+			"accounts"  : self.accounts.encode()
+			])
+	}
 }
 
 extension Pet: Decodable, Encodable {

--- a/OgraTests/OgraModel.swift
+++ b/OgraTests/OgraModel.swift
@@ -47,7 +47,7 @@ extension User: Decodable, Encodable {
 			"pet"       : self.pet.encode(),
 			"nicknames" : self.nicknames.encode(),
 			"accounts"  : self.accounts.encode()
-			])
+		])
 	}
 }
 

--- a/OgraTests/OgraModel.swift
+++ b/OgraTests/OgraModel.swift
@@ -17,6 +17,7 @@ struct User {
 	let email: String?
 	let pet: Pet?
     let nicknames: [String]?
+    let accounts: [String:String]?
 }
 struct Pet {
 	let name: String
@@ -24,8 +25,8 @@ struct Pet {
 
 // MARK: - JSON Encoding and Decoding
 extension User: Decodable, Encodable {
-    static func create(id: Int)(name: String)(email: String?)(pet: Pet?)(nicknames: [String]?) -> User {
-        return User(id:id, name:name, email:email, pet:pet, nicknames:nicknames)
+    static func create(id: Int)(name: String)(email: String?)(pet: Pet?)(nicknames: [String]?)(accounts: [String:String]?) -> User {
+        return User(id:id, name:name, email:email, pet:pet, nicknames:nicknames, accounts:accounts)
     }
     
     static func decode(j: JSON) -> Decoded<User> {
@@ -35,6 +36,7 @@ extension User: Decodable, Encodable {
             <*> j <|?  "email"
             <*> j <|?  "pet"
             <*> j <||? "nicknames"
+            <*> .optional(flatReduce(["accounts"], initial: j, combine: decodedJSON) >>- Dictionary<String, String>.decode)
     }
     
     func encode() -> JSON {
@@ -43,7 +45,8 @@ extension User: Decodable, Encodable {
             "name"      : self.name.encode(),
             "email"     : self.email.encode(),
             "pet"       : self.pet.encode(),
-            "nicknames" : self.nicknames.encode()
+            "nicknames" : self.nicknames.encode(),
+            "accounts"  : self.accounts.encode()
         ])
     }
 }

--- a/OgraTests/OgraTests.swift
+++ b/OgraTests/OgraTests.swift
@@ -25,6 +25,22 @@ class OgraTests: XCTestCase {
 		XCTAssertEqual(jsonIn, jsonOut)
 	}
 	
+	func testNullNicknames() {
+		let jsonIn = toJSON("{ \"id\":123, \"name\":\"John\", \"email\":\"john@gmail.com\", \"pet\":null, \"nicknames\":null, \"accounts\":{\"gmail\":\"john\"} }")
+		let user = User.decode(jsonIn).value!
+		let jsonOut = user.encode()
+		
+		XCTAssertEqual(jsonIn, jsonOut)
+	}
+	
+	func testNullAccounts() {
+		let jsonIn = toJSON("{ \"id\":123, \"name\":\"John\", \"email\":\"john@gmail.com\", \"pet\":null, \"nicknames\":[\"Johnny\"], \"accounts\":null }")
+		let user = User.decode(jsonIn).value!
+		let jsonOut = user.encode()
+		
+		XCTAssertEqual(jsonIn, jsonOut)
+	}
+	
 	func testWithPet() {
 		let jsonIn = toJSON("{ \"id\":123, \"name\":\"John\", \"email\":\"john@gmail.com\", \"pet\":{\"name\":\"Rex\"}, \"nicknames\":[\"Johnny\"], \"accounts\":{\"gmail\":\"john\"} }")
 		let user = User.decode(jsonIn).value!

--- a/OgraTests/OgraTests.swift
+++ b/OgraTests/OgraTests.swift
@@ -18,7 +18,7 @@ class OgraTests: XCTestCase {
 	}
 	
 	func testNullPet() {
-		let jsonIn = toJSON("{ \"id\":123, \"name\":\"John\", \"email\":\"john@gmail.com\", \"pet\":null }")
+		let jsonIn = toJSON("{ \"id\":123, \"name\":\"John\", \"email\":\"john@gmail.com\", \"pet\":null, \"nicknames\":[\"Johnny\"] }")
 		let user = User.decode(jsonIn).value!
 		let jsonOut = user.encode()
 		
@@ -26,7 +26,7 @@ class OgraTests: XCTestCase {
 	}
 	
 	func testWithPet() {
-		let jsonIn = toJSON("{ \"id\":123, \"name\":\"John\", \"email\":\"john@gmail.com\", \"pet\":{\"name\":\"Rex\"} }")
+		let jsonIn = toJSON("{ \"id\":123, \"name\":\"John\", \"email\":\"john@gmail.com\", \"pet\":{\"name\":\"Rex\"}, \"nicknames\":[\"Johnny\"] }")
 		let user = User.decode(jsonIn).value!
 		let jsonOut = user.encode()
 		
@@ -34,7 +34,7 @@ class OgraTests: XCTestCase {
 	}
 
 	func testPassingToJSONSerialization() {
-		let json = toJSON("{ \"id\":123, \"name\":\"John\", \"email\":\"john@gmail.com\", \"pet\":{\"name\":\"Rex\"} }")
+		let json = toJSON("{ \"id\":123, \"name\":\"John\", \"email\":\"john@gmail.com\", \"pet\":{\"name\":\"Rex\"}, \"nicknames\":[\"Johnny\"] }")
 		let user = User.decode(json).value!
 
 		let jsonObject = user.encode().JSONObject()

--- a/OgraTests/OgraTests.swift
+++ b/OgraTests/OgraTests.swift
@@ -18,7 +18,7 @@ class OgraTests: XCTestCase {
 	}
 	
 	func testNullPet() {
-		let jsonIn = toJSON("{ \"id\":123, \"name\":\"John\", \"email\":\"john@gmail.com\", \"pet\":null, \"nicknames\":[\"Johnny\"] }")
+		let jsonIn = toJSON("{ \"id\":123, \"name\":\"John\", \"email\":\"john@gmail.com\", \"pet\":null, \"nicknames\":[\"Johnny\"], \"accounts\":{\"gmail\":\"john\"} }")
 		let user = User.decode(jsonIn).value!
 		let jsonOut = user.encode()
 		
@@ -26,7 +26,7 @@ class OgraTests: XCTestCase {
 	}
 	
 	func testWithPet() {
-		let jsonIn = toJSON("{ \"id\":123, \"name\":\"John\", \"email\":\"john@gmail.com\", \"pet\":{\"name\":\"Rex\"}, \"nicknames\":[\"Johnny\"] }")
+		let jsonIn = toJSON("{ \"id\":123, \"name\":\"John\", \"email\":\"john@gmail.com\", \"pet\":{\"name\":\"Rex\"}, \"nicknames\":[\"Johnny\"], \"accounts\":{\"gmail\":\"john\"} }")
 		let user = User.decode(jsonIn).value!
 		let jsonOut = user.encode()
 		
@@ -34,7 +34,7 @@ class OgraTests: XCTestCase {
 	}
 
 	func testPassingToJSONSerialization() {
-		let json = toJSON("{ \"id\":123, \"name\":\"John\", \"email\":\"john@gmail.com\", \"pet\":{\"name\":\"Rex\"}, \"nicknames\":[\"Johnny\"] }")
+		let json = toJSON("{ \"id\":123, \"name\":\"John\", \"email\":\"john@gmail.com\", \"pet\":{\"name\":\"Rex\"}, \"nicknames\":[\"Johnny\"], \"accounts\":{\"gmail\":\"john\"} }")
 		let user = User.decode(json).value!
 
 		let jsonObject = user.encode().JSONObject()


### PR DESCRIPTION
This pull request adds support for calling `.encode()` directly on optional arrays of `Encodable` types such as `[String]?`

I've marked this as WIP for now since there is probably also something to be done for dictionaries, but I had some trouble when adding that to the tests (hence my question here: https://github.com/thoughtbot/Argo/issues/114).
