### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,43 @@
+# Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+## Build generated
+build/
+DerivedData
+
+## Various settings
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata
+
+## Other
+*.xccheckout
+*.moved-aside
+*.xcuserstate
+*.xcscmblueprint
+
+## Obj-C/Swift specific
+*.hmap
+*.ipa
+
+# CocoaPods
+#
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# http://guides.cocoapods.org/using/using-cocoapods.html#should-i-ignore-the-pods-directory-in-source-control
+#
+# Pods/
+
+# Carthage
+#
+# Add this line if you want to avoid checking in source code from Carthage dependencies.
+# Carthage/Checkouts
+
 Carthage/Build


### PR DESCRIPTION
This pull request updates the `.gitignore` file to use the template at https://github.com/github/gitignore/blob/master/Swift.gitignore

This fixes an issue in projects using Ogra as a git submodule where git marks the submodule as dirty due to the presence of `Ogra.xcodeproj/xcuserdata/`.

Also, contributors to Ogra will no longer see (and have to avoid committing) the untracked files in `Ogra.xcodeproj/project.xcworkspace/xcuserdata/` and `Ogra.xcodeproj/xcuserdata/` after cloning the repository.
