### PR TITLE
Use a commit hash instead of a branch name for Argo.

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "thoughtbot/Argo" "td-swift-2"
+github "thoughtbot/Argo" "c704777e4b6d3a5c2a4778a36fca393ff94b1ffa"


### PR DESCRIPTION
This pull request primarily tries to prevent this issue: https://github.com/Carthage/Carthage/issues/765

More generally, using branch names is overly permissive and makes for unstable dependencies.

Lastly, the `td-swift-2` branch of Argo is going to disappear today or tomorrow. The commit hash is more likely to stick around depending on whether the branch is merged, rebased, or something else.

I hope to submit another pull request after Argo 2.0 is tagged and released.
