### PR TITLE
Allow app extension APIs only

### DIFF
--- a/Ogra.xcodeproj/project.pbxproj
+++ b/Ogra.xcodeproj/project.pbxproj
@@ -449,6 +449,7 @@
 		BFF261C81B66432500C5552D /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -471,6 +472,7 @@
 		BFF261C91B66432500C5552D /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -492,6 +494,7 @@
 		BFF261E41B66435100C5552D /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEFINES_MODULE = YES;
@@ -518,6 +521,7 @@
 		BFF261E51B66435100C5552D /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEFINES_MODULE = YES;


### PR DESCRIPTION
The pull request allows Ogra to be used in targets that only support app extension APIs.

Since none of the unavailable APIs are being used, this is a backwards compatible change.

Some more info on this is available here: https://developer.apple.com/library/prerelease/ios/documentation/General/Conceptual/ExtensibilityPG/ExtensionScenarios.html
