### PR TITLE
Support for UInt64 and Argo 3.1

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "thoughtbot/Argo" "v3.0.0"
+github "thoughtbot/Argo" "v3.1.0"

--- a/Ogra/Encodable.swift
+++ b/Ogra/Encodable.swift
@@ -55,6 +55,12 @@ extension UInt: Encodable {
 	}
 }
 
+extension UInt64: Encodable {
+	public func encode() -> JSON {
+		return .Number(NSNumber(unsignedLongLong: self))
+	}
+}
+
 extension Optional where Wrapped: Encodable {
 	public func encode() -> JSON {
 		switch self {
@@ -119,6 +125,12 @@ extension Encodable where Self: RawRepresentable, Self.RawValue == Float {
 extension Encodable where Self: RawRepresentable, Self.RawValue == UInt {
     public func encode() -> JSON {
         return .Number(self.rawValue)
+    }
+}
+
+extension Encodable where Self: RawRepresentable, Self.RawValue == UInt64 {
+    public func encode() -> JSON {
+        return .Number(NSNumber(unsignedLongLong: self.rawValue))
     }
 }
 

--- a/OgraTests/OgraModel.swift
+++ b/OgraTests/OgraModel.swift
@@ -54,6 +54,10 @@ enum UIntDialingCode: UInt {
     case UnitedStates = 1
 }
 
+enum UInt64DialingCode: UInt64 {
+    case UnitedKingdom = 44
+    case UnitedStates = 1
+}
 
 // MARK: - JSON Encoding and Decoding
 extension User: Decodable, Encodable {
@@ -108,3 +112,4 @@ extension IntDialingCode: Decodable, Encodable {}
 extension DoubleDialingCode: Encodable {}
 extension FloatDialingCode: Encodable {}
 extension UIntDialingCode: Encodable {}
+extension UInt64DialingCode: Encodable {}

--- a/OgraTests/OgraTests.swift
+++ b/OgraTests/OgraTests.swift
@@ -97,6 +97,13 @@ class OgraTests: XCTestCase {
 		XCTAssertEqual(json, encoded)
 	}
 	
+	func testRawRepresentableUInt64Type() {
+		let dialingCode: UInt64DialingCode = .UnitedStates
+		let json: JSON = .Number(NSNumber(unsignedLongLong: dialingCode.rawValue))
+		let encoded = dialingCode.encode()
+		XCTAssertEqual(json, encoded)
+	}
+	
 	func testConversionToAnyObject() {
 		XCTAssertEqual(JSON.Null.JSONObject() as? NSNull, NSNull())
 		XCTAssertEqual(JSON.String("42").JSONObject() as? String, "42")
@@ -114,6 +121,7 @@ class OgraTests: XCTestCase {
 		XCTAssertEqual(Double(42.42).encode(), JSON.Number(NSNumber(double: 42.42)))
 		XCTAssertEqual(Float(42.42).encode(), JSON.Number(NSNumber(float: 42.42)))
 		XCTAssertEqual(UInt(42).encode(), JSON.Number(NSNumber(unsignedLong: 42)))
+		XCTAssertEqual(UInt64(42).encode(), JSON.Number(NSNumber(unsignedLongLong: 42)))
 		XCTAssertEqual(("42" as String?).encode(), JSON.String("42"))
 		XCTAssertEqual((nil as String?).encode(), JSON.Null)
 	}


### PR DESCRIPTION
Matching UInt64 support that was added to Argo in thoughtbot/Argo#396
